### PR TITLE
Add Hand Equity Calculation Feature

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,24 @@
+{
+  "originHash" : "6be63dc702f6eac6ff604d71db2e31ebbc97cd851d4084e147baf034a91844f1",
+  "pins" : [
+    {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms",
+      "state" : {
+        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
+        "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics.git",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Package.swift
+++ b/Package.swift
@@ -19,14 +19,16 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-algorithms", from: "1.2.1"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "PokerKit",
-            dependencies: [],
+            dependencies: [
+                .product(name: "Algorithms", package: "swift-algorithms"),
+            ],
             resources: [.copy("Resources")],
             swiftSettings: [
                 .enableExperimentalFeature("StrictConcurrency")

--- a/Sources/PokerKit/Implementation/DefaultEquityCalculator.swift
+++ b/Sources/PokerKit/Implementation/DefaultEquityCalculator.swift
@@ -1,0 +1,101 @@
+//
+//  File.swift
+//  PokerKit
+//
+//  Created by Antti Ahvenlampi on 26.10.2025.
+//
+
+import Foundation
+import Algorithms
+
+private let maxCombinationsCount: Int = 1_000_000
+
+struct DefaultEquityCalculator {
+    private let evaluator: HandEvaluator
+    
+    init(evaluator: HandEvaluator) {
+        self.evaluator = evaluator
+    }
+    
+}
+
+extension DefaultEquityCalculator: EquityCalculator {
+    
+    func calculateEquity(hand: [Card], board: [Card], numOpponents: Int) -> Double {
+        precondition(hand.count == 2, "Holdem hand must have 2 cards")
+        precondition(board.count <= 5, "Holdem board can have 0-5 cards")
+        precondition(numOpponents > 0, "No sense to calculate equity for a single player")
+        precondition(Set(hand + board).count == (hand.count + board.count), "Cannot have duplicate cards")
+        
+        var deck = Rank.allCases.flatMap { r in Suit.allCases.map { s in Card(rank: r, suit: s) } }
+        deck.removeAll { hand.contains($0) || board.contains($0) }
+        
+        let boardHandle = board.reduce(HandHandle.empty) { evaluator.evaluate(card: $1, handle: $0) }
+        let missingBoardCount = 5 - board.count
+        let opponentCardsCount = 2 * numOpponents
+        let combinations = deck
+            .combinations(ofCount: missingBoardCount + opponentCardsCount)
+        let combinationsCount = combinations.count
+        if combinationsCount > maxCombinationsCount {
+            // Monte Carlo estimation if too many combinations to go through
+            var sum: Double = 0.0
+            for _ in 0..<maxCombinationsCount {
+                let combination = Array(deck.shuffled()
+                    .prefix(missingBoardCount + opponentCardsCount))
+                sum += calculateEquity(
+                    hand: hand,
+                    boardHandle: boardHandle,
+                    combination: combination,
+                    missingBoardCount: missingBoardCount,
+                    opponentCardsCount: opponentCardsCount)
+            }
+            return sum / Double(maxCombinationsCount)
+        } else {
+            return combinations
+                .reduce(0.0) { totalEquity, combination in
+                    let equity = calculateEquity(
+                        hand: hand,
+                        boardHandle: boardHandle,
+                        combination: combination,
+                        missingBoardCount: missingBoardCount,
+                        opponentCardsCount: opponentCardsCount)
+                    return totalEquity + equity
+                } / Double(combinationsCount)
+        }
+    }
+    
+    private func calculateEquity(hand: [Card], boardHandle: HandHandle, combination: [Card], missingBoardCount: Int, opponentCardsCount: Int) -> Double {
+        let otherPlayerHands = combination
+            .dropLast(missingBoardCount)
+            .chunks(ofCount: 2)
+        let missingBoard = combination
+            .dropFirst(opponentCardsCount)
+        let handle = missingBoard
+            .reduce(boardHandle) { evaluator.evaluate(card: $1, handle: $0) }
+        return calculateEquity(
+            hand: hand,
+            boardHandle: handle,
+            opponentHands: otherPlayerHands)
+    }
+    
+    private func calculateEquity<S: Sequence>(hand: [Card], boardHandle: HandHandle, opponentHands: S) -> Double where S.Element == ArraySlice<Card> {
+        guard let heroRank = evaluate(hand: hand, boardHandle: boardHandle) else {
+            return 0.0
+        }
+        
+        let enemyRanks = opponentHands
+            .compactMap { evaluate(hand: Array($0), boardHandle: boardHandle) }
+        
+        if let maxEnemyRank = enemyRanks.max(), heroRank < maxEnemyRank {
+            return 0.0
+        }
+        
+        return 1.0 / Double(enemyRanks.count(where: { $0 == heroRank }) + 1)
+    }
+    
+    private func evaluate(hand: [Card], boardHandle: HandHandle) -> HandRank? {
+        return evaluator.evaluate(handle: hand
+            .reduce(boardHandle, { evaluator.evaluate(card: $1, handle: $0) }))
+    }
+    
+}

--- a/Sources/PokerKit/Models/Card.swift
+++ b/Sources/PokerKit/Models/Card.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct Card {
+public struct Card: Equatable, Hashable {
     public let rank: Rank
     public let suit: Suit
 

--- a/Sources/PokerKit/Models/HandRank.swift
+++ b/Sources/PokerKit/Models/HandRank.swift
@@ -19,7 +19,7 @@ public enum HandCategory: UInt16 {
     case straightFlush = 9
 }
 
-public struct HandRank {
+public struct HandRank: Equatable {
 
     public let category: HandCategory
     public let rank: UInt16

--- a/Sources/PokerKit/Models/Rank.swift
+++ b/Sources/PokerKit/Models/Rank.swift
@@ -19,7 +19,7 @@ public enum Rank: UInt8, CaseIterable {
 extension Rank: CustomStringConvertible {
     public var description: String {
         if rawValue < 8 {
-            return String(rawValue)
+            return String(rawValue + 2)
         } else {
             return ["T", "J", "Q", "K", "A"][Int(rawValue - 8)]
         }

--- a/Sources/PokerKit/PokerKit.swift
+++ b/Sources/PokerKit/PokerKit.swift
@@ -12,5 +12,9 @@ public enum PokerKit {
     public static func lookupTableHandEvaluator() -> HandEvaluator {
         return LookupTableHandEvaluator()
     }
+    
+    public static func defaultEquityCalculator(evaluator: HandEvaluator = lookupTableHandEvaluator()) -> EquityCalculator {
+        return DefaultEquityCalculator(evaluator: evaluator)
+    }
 
 }

--- a/Sources/PokerKit/Protocols/EquityCalculator.swift
+++ b/Sources/PokerKit/Protocols/EquityCalculator.swift
@@ -1,0 +1,12 @@
+//
+//  EquityEvaluator.swift
+//  PokerKit
+//
+//  Created by Antti Ahvenlampi on 26.10.2025.
+//
+
+import Foundation
+
+public protocol EquityCalculator {
+    func calculateEquity(hand: [Card], board: [Card], numOpponents: Int) -> Double
+}

--- a/Tests/PokerKitTests/EquityCalculatorTests.swift
+++ b/Tests/PokerKitTests/EquityCalculatorTests.swift
@@ -1,0 +1,55 @@
+//
+//  EquityCalculatorTests.swift
+//  PokerKit
+//
+//  Created by Antti Ahvenlampi on 26.10.2025.
+//
+
+import Testing
+@testable import PokerKit
+
+@Suite("Equity Calculator Tests")
+struct EquityCalculatorTests {
+    
+    private let calculator = PokerKit.defaultEquityCalculator()
+
+    @Test("Test equity for nuts in 2-player game")
+    func calculateNutsEquity() throws {
+        #expect(1.0 == calculator.calculateEquity(hand: [
+            Card(rank: Rank.ace, suit: Suit.club),
+            Card(rank: Rank.king, suit: Suit.club)
+        ], board: [
+            Card(rank: Rank.queen, suit: Suit.club),
+            Card(rank: Rank.jack, suit: Suit.club),
+            Card(rank: Rank.ten, suit: Suit.club),
+        ], numOpponents: 1))
+    }
+    
+    @Test("Test equity for AA in 2-player game")
+    func calculateAAEquity() throws {
+        #expect(abs(calculator.calculateEquity(hand: [
+            Card(rank: Rank.ace, suit: Suit.club),
+            Card(rank: Rank.ace, suit: Suit.heart)
+        ], board: [
+        ], numOpponents: 1) - 0.85) < 0.01)
+    }
+    
+    @Test("Test equity for AKs in 2-player game")
+    func calculateAKsEquity() throws {
+        #expect(abs(calculator.calculateEquity(hand: [
+            Card(rank: Rank.ace, suit: Suit.club),
+            Card(rank: Rank.king, suit: Suit.club)
+        ], board: [
+        ], numOpponents: 1) - 0.67) < 0.01)
+    }
+    
+    @Test("Test equity for 72o in 9-player game")
+    func calculate72oEquity() throws {
+        #expect(abs(calculator.calculateEquity(hand: [
+            Card(rank: Rank.seven, suit: Suit.club),
+            Card(rank: Rank.two, suit: Suit.heart)
+        ], board: [
+        ], numOpponents: 8) - 0.05) < 0.01)
+    }
+
+}


### PR DESCRIPTION
## Summary

- Adds `EquityCalculator` protocol and `DefaultEquityCalculator` implementation for calculating Texas Hold'em hand equity
- Calculates win probability for a hand against a specified number of opponents
- Uses combinatorial analysis for exhaustive evaluation when feasible
- Falls back to Monte Carlo simulation (1M samples) for scenarios with too many combinations
- Adds swift-algorithms dependency for efficient combination generation
- Makes `Card` and `HandRank` conform to `Equatable`/`Hashable` to support equity calculations
- Fixes bug in `Rank.description` that was showing raw value instead of actual rank (2-A)

## Test Plan

- [x] New test suite `EquityCalculatorTests` validates equity calculations for common scenarios:
  - Nuts (100% equity) - royal flush on board
  - Pocket aces preflop (~85% equity heads-up)
  - AKs preflop (~67% equity heads-up)
  - 72o preflop in 9-player game (~5% equity)
- [x] All tests pass locally
- [x] SwiftLint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)